### PR TITLE
Add CI status rollup gate to satisfy org rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,17 @@ jobs:
           harn add "$GITHUB_WORKSPACE@HEAD"
           printf 'import "notion-sdk-harn/default"\n' > smoke.harn
           harn check smoke.harn
+
+  ci-status:
+    name: CI status
+    if: always()
+    needs: [harn]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped"


### PR DESCRIPTION
Adds a rollup job named `CI status` to satisfy the `burin-labs/main protection` org ruleset which requires that exact context name.