### PR TITLE
Pin harn-cli 0.8.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ management, and the v0 milestones.
 Install the pinned Harn CLI from crates.io and run the local gate:
 
 ```sh
-cargo install harn-cli --version "$(cat .harn-version)" --locked
+version="$(tr -d '[:space:]' < .harn-version)"
+cargo install harn-cli --version "$version" --locked
 harn install --locked
 harn check src scripts
 harn lint src scripts

--- a/README.md
+++ b/README.md
@@ -106,13 +106,17 @@ prompt. **Read [SESSION_PROMPT.md](./SESSION_PROMPT.md) before making changes.**
 Install the pinned Harn CLI from crates.io and resolve package dependencies:
 
 ```sh
-cargo install harn-cli --version "$(cat .harn-version)" --locked
+version="$(tr -d '[:space:]' < .harn-version)"
+cargo install harn-cli --version "$version" --locked
 harn install --locked
 harn check src scripts
 harn lint src scripts
 harn fmt --check src scripts
 harn run scripts/regen.harn
 ```
+
+CI uses the same `.harn-version` pin, installing `harn-cli` from crates.io
+instead of relying on an ambient sibling checkout.
 
 ## License
 

--- a/SESSION_PROMPT.md
+++ b/SESSION_PROMPT.md
@@ -158,13 +158,13 @@ The codegen will eventually produce code matching this shape.
   but not required for v0.
 - Run before committing:
   ```sh
-  cd /Users/ksinder/projects/harn
-  cargo run --quiet --bin harn -- check /Users/ksinder/projects/notion-sdk-harn/src/lib.harn
-  cargo run --quiet --bin harn -- lint  /Users/ksinder/projects/notion-sdk-harn/src/lib.harn
-  cargo run --quiet --bin harn -- fmt --check /Users/ksinder/projects/notion-sdk-harn/src/lib.harn
-  for t in /Users/ksinder/projects/notion-sdk-harn/tests/*.harn; do
-    cargo run --quiet --bin harn -- run "$t" || exit 1
-  done
+  version="$(tr -d '[:space:]' < .harn-version)"
+  cargo install harn-cli --version "$version" --locked
+  harn install --locked
+  harn check src scripts
+  harn lint src scripts
+  harn fmt --check src scripts
+  harn run scripts/regen.harn
   ```
 
 ## Definition of done for v0

--- a/scripts/regen.harn
+++ b/scripts/regen.harn
@@ -25,6 +25,31 @@ let CODEGEN_OPTIONS = {
   header_overrides: {"Notion-Version": "2022-06-28"},
 }
 
+fn _sh_quote(value: string) -> string {
+  return "'" + replace(value, "'", "'\"'\"'") + "'"
+}
+
+fn _harn_cmd(args: string) -> string {
+  let bin = env("HARN_BIN")
+  if bin != nil && bin != "" {
+    return _sh_quote(bin) + " " + args
+  }
+  return "harn " + args
+}
+
+fn _format_generated(source: string) -> string {
+  let path = temp_dir() + "/notion-sdk-harn-generated.harn"
+  write_file(path, source)
+  let result = shell(_harn_cmd("fmt " + _sh_quote(path)))
+  if !result.success {
+    if result.stderr != "" {
+      println(result.stderr.trim())
+    }
+    throw "failed to format generated output"
+  }
+  return read_file(path)
+}
+
 pipeline default() {
   let apply_mode = argv.contains("--apply")
   let raw = read_file(FIXTURE_PATH)
@@ -33,7 +58,7 @@ pipeline default() {
   println("parsed ${doc.info.title} (OpenAPI ${doc.openapi})")
   println("  operations: ${len(ops)}")
   println("  schemas:    ${len(doc.components.schemas)}")
-  let generated = codegen_module(doc, CODEGEN_OPTIONS)
+  let generated = _format_generated(codegen_module(doc, CODEGEN_OPTIONS))
   let generated_lines = len(split(generated, "\n"))
   println("  generated:  ${len(generated)} bytes, ${generated_lines} lines")
   let current = if file_exists(OUTPUT_PATH) {


### PR DESCRIPTION
## Summary

- Pin the repo's Harn CLI toolchain to `harn-cli` 0.8.1 via `.harn-version`.
- Keep contributor docs aligned with the crates.io install path used by CI.
- Normalize generated SDK output through `harn fmt` inside `scripts/regen.harn` so `fmt --check` and the regen drift check can both pass under the pinned CLI.

Closes #5.

## Verification

- `harn install && harn check src scripts && harn lint src scripts && harn fmt --check src scripts && harn run scripts/regen.harn`
- Consumer smoke: `harn add /Users/ksinder/.codex/worktrees/1a31/notion-sdk-harn@HEAD` plus `harn check smoke.harn`
- Isolated crates.io install: `cargo install harn-cli --version 0.8.1 --locked --root <temp>` followed by `harn install`, `harn check src scripts`, `harn fmt --check src scripts`, and `harn run scripts/regen.harn`

Note: `harn lint` still reports existing generated missing-HarnDoc warnings for variant helpers; it exits successfully and this PR does not change the generated API surface.
