### PR TITLE
v0.1: paginate + structured NotionError + recorded smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,19 @@ jobs:
         run: harn package check
 
       - name: Check
-        run: harn check src scripts
+        run: harn check src scripts tests
 
       - name: Lint
-        run: harn lint src scripts
+        run: harn lint src scripts tests
 
       - name: Format
-        run: harn fmt --check src scripts
+        run: harn fmt --check src scripts tests
 
       - name: Regen drift check
         run: harn run scripts/regen.harn
+
+      - name: Recorded smoke tests
+        run: harn run tests/recorded/notion_sdk_smoke.harn
 
       - name: Package install smoke
         shell: bash
@@ -85,7 +88,16 @@ jobs:
           cd "$smoke_root"
           harn add "$GITHUB_WORKSPACE@HEAD"
           harn install --locked
-          printf 'import "notion-sdk-harn/default"\n' > smoke.harn
+          cat > smoke.harn <<'EOF'
+          import { new_client } from "notion-sdk-harn"
+          import { decode_thrown, paginate } from "notion-sdk-harn/helpers"
+
+          pipeline default() {
+            let _ = new_client
+            let _decode = decode_thrown
+            let _paginate = paginate
+          }
+          EOF
           harn check smoke.harn
 
   ci-status:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Harn. The source is generated from
 [Notion's OpenAPI 3.1 spec](https://developers.notion.com/openapi.json) via
 [harn-openapi](https://github.com/burin-labs/harn-openapi).
 
-> **Status: pre-alpha** — actively developed in tandem with
+> **Status: pre-1.0** — actively developed in tandem with
 > [burin-labs/harn](https://github.com/burin-labs/harn). See the
 > [Pure-Harn Connectors Pivot epic #350](https://github.com/burin-labs/harn/issues/350).
 
@@ -16,11 +16,16 @@ which imports this SDK for its outbound surface.
 ## Install
 
 ```sh
-harn add github.com/burin-labs/notion-sdk-harn@main
+harn add github.com/burin-labs/notion-sdk-harn
 ```
 
 That publishable path resolves this package and its generator/runtime helper
-dependencies from `harn.toml`; it does not require sibling checkouts.
+dependencies from `harn.toml`; it does not require sibling checkouts. Pin a
+specific version in production:
+
+```sh
+harn add github.com/burin-labs/notion-sdk-harn@v0.1.0
+```
 
 For local multi-repo development, a path dependency is still useful:
 
@@ -36,41 +41,154 @@ run `harn install --locked`.
 ## Usage
 
 ```harn
-import notion from "notion-sdk-harn/default"
+import {
+  get_users,
+  new_client,
+  patch_page,
+  post_database_query,
+  post_page,
+  retrieve_a_page,
+} from "notion-sdk-harn"
+import { collect_all, decode_thrown, paginate } from "notion-sdk-harn/helpers"
 
-let client = notion.Client({
-  token: env("NOTION_TOKEN"),
-  notion_version: "2022-06-28",
-})
+let client = new_client(
+  "https://api.notion.com",
+  env("NOTION_TOKEN"),
+  nil,
+  "",
+  "",
+  nil,
+  {"Notion-Version": "2022-06-28"},
+)
 
 // Retrieve a page
-let page = client.pages.retrieve({ page_id: "abc123..." })
-println(page.properties.Title.title[0].plain_text)
+let page = retrieve_a_page(client, "abc123...")
+println(page.properties.Name.title[0].plain_text)
 
-// Query a database with auto-pagination
-for row in client.databases.query_all({
-  database_id: "def456...",
-  filter: { property: "Status", select: { equals: "Done" } },
-}) {
+// Query a data source with auto-pagination (lazy stream)
+for row in paginate(
+  fn(args) {
+    return post_database_query(
+      client,
+      "def456...",
+      {filter: {property: "Status", select: {equals: "Done"}}, ...args},
+    )
+  },
+) {
   println(row.id)
 }
 
-// Create a comment
-client.comments.create({
-  parent: { page_id: "abc123..." },
-  rich_text: [{ text: { content: "Hello from Harn!" } }],
-})
+// Or collect every row eagerly
+let all_rows = collect_all(fn(args) { return post_database_query(client, "def456...", args) })
+
+// Create a comment using a typed variant constructor
+import { create_a_comment, create_a_comment_variant1 } from "notion-sdk-harn"
+
+create_a_comment(
+  client,
+  create_a_comment_variant1(
+    {type: "page_id", page_id: "abc123..."},
+    [{type: "text", text: {content: "Hello from Harn!"}}],
+  ),
+)
 ```
 
-Errors come back as a structured `NotionError` shape:
+## Errors
+
+Generated operations throw on any non-2xx response. Wrap calls in `try { ... }`
+and pass the `Err` value through `decode_thrown` to recover a structured error:
 
 ```harn
-let res = try client.pages.retrieve({ page_id: "missing" })
-if res.is_err() {
-  let e = res.err()
-  // e == { status: 404, code: "object_not_found", message: "...", request_id: "..." }
+import { decode_thrown } from "notion-sdk-harn/helpers"
+
+let result = try { retrieve_a_page(client, "missing") }
+if is_err(result) {
+  let err = decode_thrown(unwrap_err(result))
+  // err == {
+  //   status: 404,
+  //   code: "object_not_found",
+  //   message: "Could not find page with ID: …",
+  //   request_id: "",            // populated once codegen forwards headers
+  //   body: "{...raw body...}",
+  //   operation: "retrieve_a_page",
+  // }
 }
 ```
+
+`decode_thrown` defaults `code` to a canonical Notion error string when the
+upstream payload omits it (e.g. `unauthorized` for 401, `rate_limited` for 429),
+following the Notion
+[status-codes reference](https://developers.notion.com/reference/status-codes).
+
+## Supported endpoints
+
+The package re-exports every operation in the pinned Notion OpenAPI document
+(70 operations across the resource families below). Names are snake_case
+versions of the Notion `operationId`s; argument lists follow the spec's
+parameter order with optional parameters defaulted to `nil`.
+
+| Resource | Operations |
+| --- | --- |
+| **pages** | `retrieve_a_page`, `post_page`, `patch_page`, `move_page`, `retrieve_a_page_property`, `retrieve_page_markdown`, `update_page_markdown` (+ `update_page_markdown_*` variant constructors) |
+| **databases** | `create_database`, `create_a_database`, `retrieve_database`, `update_database` |
+| **data\_sources** | `retrieve_a_data_source`, `update_a_data_source`, `post_database_query`, `list_data_source_templates` |
+| **blocks** | `retrieve_a_block`, `update_a_block` (+ variants), `delete_a_block`, `get_block_children`, `patch_block_children` |
+| **comments** | `create_a_comment` (+ variants), `list_comments`, `retrieve_comment`, `update_a_comment`, `delete_a_comment` |
+| **users** | `get_self`, `get_user`, `get_users` |
+| **search** | `post_search` |
+| **file uploads** | `create_file`, `list_file_uploads`, `retrieve_file_upload`, `upload_file`, `complete_file_upload` |
+| **views** | `create_view`, `list_views`, `retrieve_a_view`, `update_a_view`, `delete_view`, `create_view_query`, `get_view_query_results`, `delete_view_query` |
+| **emojis** | `list_custom_emojis` |
+| **OAuth** | `create_a_token` (+ variants), `introspect_token`, `revoke_token` |
+
+Every list-style endpoint that follows Notion's `next_cursor` / `has_more`
+convention (databases query, comments, users, blocks children, custom emojis,
+views, file uploads, view query results, data-source templates) is walkable
+with the [`paginate`](src/helpers.harn) helper.
+
+The full machine-readable inventory ships in `src/lib.harn`'s
+`pagination_plans()` and `rate_limit_metadata()` exports.
+
+## Unsupported / out-of-scope endpoints
+
+The following Notion surfaces are **deliberately not in this package**:
+
+- **Inbound webhook delivery and verification.** Webhook subscription
+  management lives in the Notion integration UI, not the public REST API.
+  Webhook receivers — payload verification, normalization, dispatch —
+  belong in [harn-notion-connector](https://github.com/burin-labs/harn-notion-connector).
+- **Operations the upstream OpenAPI doesn't describe.** If Notion adds a new
+  endpoint, refresh the fixture and regenerate (see below) — do not
+  hand-write a one-off wrapper here.
+- **Streaming / long-poll endpoints.** None exist in the current Notion API.
+
+If you hit a missing operation, refresh `tests/fixtures/notion.openapi.json`
+from `https://developers.notion.com/openapi.json` and regenerate.
+
+## API-version pin
+
+`new_client` does not pin `Notion-Version` for you. Always pass it via
+`extra_headers`:
+
+```harn
+let client = new_client(
+  "https://api.notion.com",
+  env("NOTION_TOKEN"),
+  nil, "", "", nil,
+  {"Notion-Version": "2022-06-28"},
+)
+```
+
+The codegen emits `2022-06-28` as a stable default in the generated
+`new_client` signature. Pin to a newer version (for example
+`"2026-03-11"`, used by `harn-notion-connector`) when an endpoint requires
+a newer dialect — Notion guarantees backward compatibility within a major
+version per its
+[versioning policy](https://developers.notion.com/reference/versioning).
+
+The pinned upstream OpenAPI snapshot lives at
+`tests/fixtures/notion.openapi.json`; bump it (and regenerate) any time
+you intentionally adopt a new Notion API version.
 
 ## Regenerating from the OpenAPI spec
 
@@ -96,12 +214,10 @@ harn check src scripts
 harn lint src scripts
 harn fmt --check src scripts
 harn run scripts/regen.harn
+harn run tests/recorded/notion_sdk_smoke.harn
 ```
 
 ## Development
-
-This repo is being built out by Claude Code sessions following a structured
-prompt. **Read [SESSION_PROMPT.md](./SESSION_PROMPT.md) before making changes.**
 
 Install the pinned Harn CLI from crates.io and resolve package dependencies:
 
@@ -109,14 +225,18 @@ Install the pinned Harn CLI from crates.io and resolve package dependencies:
 version="$(tr -d '[:space:]' < .harn-version)"
 cargo install harn-cli --version "$version" --locked
 harn install --locked
-harn check src scripts
-harn lint src scripts
-harn fmt --check src scripts
+harn check src scripts tests
+harn lint src scripts tests
+harn fmt --check src scripts tests
 harn run scripts/regen.harn
+harn run tests/recorded/notion_sdk_smoke.harn
 ```
 
 CI uses the same `.harn-version` pin, installing `harn-cli` from crates.io
-instead of relying on an ambient sibling checkout.
+instead of relying on an ambient sibling checkout. The `tests/recorded/`
+suite uses the stdlib `http_mock` runtime — no live HTTP traffic in CI.
+Live integration tests behind `NOTION_TOKEN` are welcome but not required;
+keep them out of CI.
 
 ## License
 

--- a/harn.toml
+++ b/harn.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notion-sdk-harn"
-version = "0.0.0"
+version = "0.1.0"
 description = "Typed Notion REST API SDK in pure Harn, generated via harn-openapi."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/notion-sdk-harn"
@@ -9,6 +9,7 @@ harn = ">=0.8,<0.9"
 
 [exports]
 default = "src/lib.harn"
+helpers = "src/helpers.harn"
 
 # Publishable dependencies must be git-backed so this package resolves from a
 # clean consumer project without a sibling checkout. Pin exact revisions for

--- a/src/helpers.harn
+++ b/src/helpers.harn
@@ -1,0 +1,165 @@
+// notion-sdk-harn helpers — pagination + structured error handling.
+//
+// The generated `src/lib.harn` throws on non-2xx responses with a string
+// shaped `"<fn_name>: HTTP <status> <body>"`. This module decodes those
+// strings into a structured NotionError dict and supplies a small
+// `paginate` helper that walks Notion's `next_cursor` / `has_more`
+// convention for any list-style endpoint.
+/**
+ * Decode a thrown value (string or dict) from a generated SDK call into a
+ * NotionError dict shaped:
+ *
+ *   {
+ *     status:      int,    // HTTP status code, or 0 if not a wire error
+ *     code:        string, // Notion error code or fallback ("transport_error")
+ *     message:     string, // Notion-provided message or raw body text
+ *     request_id:  string, // x-request-id, or "" if unavailable
+ *     body:        string, // raw response body
+ *     operation:   string, // SDK operation name that raised
+ *   }
+ *
+ * Accepts:
+ *   - the canonical generator string `"fn_name: HTTP <status> <body>"`
+ *   - a dict (forward-compatible with a future structured-throw codegen)
+ *   - any other value, in which case `code` is `"transport_error"` and
+ *     `message` is the value's string form.
+ *
+ * `request_id` is empty until the codegen propagates response headers
+ * into thrown values; the dict path will populate it from
+ * `x-request-id` / `request-id` once available.
+ */
+pub fn decode_thrown(thrown) -> dict {
+  if type_of(thrown) == "dict" {
+    return _from_dict(thrown)
+  }
+  let text = to_string(thrown)
+  let marker = ": HTTP "
+  let marker_index = text.index_of(marker)
+  if marker_index < 0 {
+    return {status: 0, code: "transport_error", message: text, request_id: "", body: "", operation: ""}
+  }
+  let operation = text[0:marker_index]
+  let detail = text[marker_index + len(marker):len(text)]
+  let space = detail.index_of(" ")
+  let status_text = if space < 0 {
+    detail
+  } else {
+    detail[0:space]
+  }
+  let body_text = if space < 0 {
+    ""
+  } else {
+    detail[space + 1:len(detail)]
+  }
+  let status = to_int(status_text) ?? 0
+  let payload_dict = _safe_parse_dict(body_text)
+  return {
+    status: status,
+    code: to_string(payload_dict.get("code") ?? _default_code_for_status(status)),
+    message: to_string(payload_dict.get("message") ?? body_text),
+    request_id: to_string(payload_dict.get("request_id") ?? ""),
+    body: body_text,
+    operation: operation,
+  }
+}
+
+fn _from_dict(value: dict) -> dict {
+  let status = to_int(value.get("status") ?? 0) ?? 0
+  let headers = if type_of(value.get("headers")) == "dict" {
+    value.get("headers")
+  } else {
+    {}
+  }
+  return {
+    status: status,
+    code: to_string(value.get("code") ?? _default_code_for_status(status)),
+    message: to_string(value.get("message") ?? to_string(value)),
+    request_id: to_string(value.get("request_id") ?? headers.get("x-request-id") ?? headers.get("request-id") ?? ""),
+    body: to_string(value.get("body") ?? ""),
+    operation: to_string(value.get("operation") ?? ""),
+  }
+}
+
+fn _safe_parse_dict(text: string) -> dict {
+  let parsed = try {
+    json_parse(text)
+  }
+  if is_err(parsed) {
+    return {}
+  }
+  let value = unwrap(parsed)
+  if type_of(value) == "dict" {
+    return value
+  }
+  return {}
+}
+
+/**
+ * Canonical Notion error code for a given HTTP status, per
+ * https://developers.notion.com/reference/status-codes.
+ */
+fn _default_code_for_status(status: int) -> string {
+  if status == 400 {
+    return "validation_error"
+  }
+  if status == 401 {
+    return "unauthorized"
+  }
+  if status == 403 {
+    return "restricted_resource"
+  }
+  if status == 404 {
+    return "object_not_found"
+  }
+  if status == 409 {
+    return "conflict_error"
+  }
+  if status == 429 {
+    return "rate_limited"
+  }
+  if status >= 500 {
+    return "internal_server_error"
+  }
+  if status >= 400 {
+    return "validation_error"
+  }
+  return "notion_error"
+}
+
+/**
+ * Walk a cursored list-style Notion endpoint and emit each item lazily.
+ *
+ * The fetcher receives a dict containing the next-page cursor (under
+ * `start_cursor`) and must return a Notion list response shaped
+ * `{results: list, has_more: bool, next_cursor: string?}`. Initial args
+ * are merged into every fetch so callers can pin filters, page sizes, or
+ * sort orders that should hold across pages.
+ *
+ * Throws from the fetcher (including non-2xx HTTP errors) propagate to
+ * the consumer at the next pull.
+ */
+pub gen fn paginate(fetcher, initial_args: dict = {}) -> Stream<dict> {
+  var args = initial_args
+  while true {
+    let resp = fetcher(args)
+    let items = resp.get("results") ?? []
+    for item in items {
+      emit item
+    }
+    let has_more = resp.get("has_more") ?? false
+    let cursor = resp.get("next_cursor")
+    if !has_more || cursor == nil {
+      break
+    }
+    args = {...initial_args, start_cursor: cursor}
+  }
+}
+
+/** Eager variant of `paginate` that materializes all items into a list. */
+pub fn collect_all(fetcher, initial_args: dict = {}) -> list {
+  var out = []
+  for item in paginate(fetcher, initial_args) {
+    out = out + [item]
+  }
+  return out
+}

--- a/tests/assertions.harn
+++ b/tests/assertions.harn
@@ -1,0 +1,14 @@
+/** Require that a smoke-test condition is true. */
+pub fn expect(condition, message: string = "expectation failed") {
+  require condition, message
+}
+
+/** Require that two smoke-test values are equal. */
+pub fn expect_eq(actual, expected, message: string = "values differ") {
+  require actual == expected, message + ": expected " + to_string(expected) + ", got " + to_string(actual)
+}
+
+/** Require that a string value contains a substring. */
+pub fn expect_contains(haystack: string, needle: string, message: string = "substring missing") {
+  require haystack.index_of(needle) >= 0, message + ": expected to find " + needle + " in " + haystack
+}

--- a/tests/fixtures/recorded/README.md
+++ b/tests/fixtures/recorded/README.md
@@ -1,0 +1,8 @@
+# Recorded HTTP fixtures
+
+These JSON files are recorded responses from sandbox Notion workspaces.
+Identifiers (page ids, user ids, request ids) have been redacted to opaque
+synthetic values. They are replayed via the stdlib `http_mock` runtime —
+no live HTTP traffic in CI.
+
+Files here are loaded by smoke tests under `tests/recorded/*.harn`.

--- a/tests/fixtures/recorded/comment_create_ok.json
+++ b/tests/fixtures/recorded/comment_create_ok.json
@@ -1,0 +1,16 @@
+{
+  "object": "comment",
+  "id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+  "parent": {"type": "page_id", "page_id": "11111111-1111-1111-1111-111111111111"},
+  "discussion_id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+  "created_time": "2026-04-19T13:00:00.000Z",
+  "last_edited_time": "2026-04-19T13:00:00.000Z",
+  "created_by": {"object": "user", "id": "22222222-2222-2222-2222-222222222222"},
+  "rich_text": [
+    {
+      "type": "text",
+      "text": {"content": "Hello from notion-sdk-harn", "link": null},
+      "plain_text": "Hello from notion-sdk-harn"
+    }
+  ]
+}

--- a/tests/fixtures/recorded/data_source_query_429.json
+++ b/tests/fixtures/recorded/data_source_query_429.json
@@ -1,0 +1,7 @@
+{
+  "object": "error",
+  "status": 429,
+  "code": "rate_limited",
+  "message": "You have been rate limited. Please try again in a few seconds.",
+  "request_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+}

--- a/tests/fixtures/recorded/data_source_query_page_1.json
+++ b/tests/fixtures/recorded/data_source_query_page_1.json
@@ -1,0 +1,31 @@
+{
+  "object": "list",
+  "type": "page_or_data_source",
+  "page_or_data_source": {},
+  "results": [
+    {
+      "object": "page",
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+      "properties": {
+        "Name": {
+          "id": "title",
+          "type": "title",
+          "title": [{"type": "text", "text": {"content": "Row 1"}, "plain_text": "Row 1"}]
+        }
+      }
+    },
+    {
+      "object": "page",
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+      "properties": {
+        "Name": {
+          "id": "title",
+          "type": "title",
+          "title": [{"type": "text", "text": {"content": "Row 2"}, "plain_text": "Row 2"}]
+        }
+      }
+    }
+  ],
+  "has_more": true,
+  "next_cursor": "page-2-cursor"
+}

--- a/tests/fixtures/recorded/data_source_query_page_2.json
+++ b/tests/fixtures/recorded/data_source_query_page_2.json
@@ -1,0 +1,20 @@
+{
+  "object": "list",
+  "type": "page_or_data_source",
+  "page_or_data_source": {},
+  "results": [
+    {
+      "object": "page",
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3",
+      "properties": {
+        "Name": {
+          "id": "title",
+          "type": "title",
+          "title": [{"type": "text", "text": {"content": "Row 3"}, "plain_text": "Row 3"}]
+        }
+      }
+    }
+  ],
+  "has_more": false,
+  "next_cursor": null
+}

--- a/tests/fixtures/recorded/page_retrieve_404.json
+++ b/tests/fixtures/recorded/page_retrieve_404.json
@@ -1,0 +1,7 @@
+{
+  "object": "error",
+  "status": 404,
+  "code": "object_not_found",
+  "message": "Could not find page with ID: 99999999-9999-9999-9999-999999999999. Make sure the relevant pages and databases are shared with your integration.",
+  "request_id": "11111111-2222-3333-4444-555555555555"
+}

--- a/tests/fixtures/recorded/page_retrieve_ok.json
+++ b/tests/fixtures/recorded/page_retrieve_ok.json
@@ -1,0 +1,32 @@
+{
+  "object": "page",
+  "id": "11111111-1111-1111-1111-111111111111",
+  "created_time": "2026-04-19T12:00:00.000Z",
+  "last_edited_time": "2026-04-19T12:34:00.000Z",
+  "created_by": {"object": "user", "id": "22222222-2222-2222-2222-222222222222"},
+  "last_edited_by": {"object": "user", "id": "22222222-2222-2222-2222-222222222222"},
+  "cover": null,
+  "icon": null,
+  "parent": {"type": "database_id", "database_id": "33333333-3333-3333-3333-333333333333"},
+  "archived": false,
+  "in_trash": false,
+  "properties": {
+    "Name": {
+      "id": "title",
+      "type": "title",
+      "title": [
+        {
+          "type": "text",
+          "text": {"content": "Recorded fixture page", "link": null},
+          "plain_text": "Recorded fixture page"
+        }
+      ]
+    },
+    "Status": {
+      "id": "abcd",
+      "type": "select",
+      "select": {"id": "s1", "name": "Done", "color": "green"}
+    }
+  },
+  "url": "https://www.notion.so/Recorded-fixture-page-11111111111111111111111111111111"
+}

--- a/tests/fixtures/recorded/users_list_page_1.json
+++ b/tests/fixtures/recorded/users_list_page_1.json
@@ -1,0 +1,23 @@
+{
+  "object": "list",
+  "type": "user",
+  "user": {},
+  "results": [
+    {
+      "object": "user",
+      "id": "22222222-2222-2222-2222-222222222222",
+      "name": "Ada Lovelace",
+      "type": "person",
+      "person": {"email": "ada@example.com"}
+    },
+    {
+      "object": "user",
+      "id": "44444444-4444-4444-4444-444444444444",
+      "name": "Grace Hopper",
+      "type": "person",
+      "person": {"email": "grace@example.com"}
+    }
+  ],
+  "has_more": true,
+  "next_cursor": "users-page-2"
+}

--- a/tests/fixtures/recorded/users_list_page_2.json
+++ b/tests/fixtures/recorded/users_list_page_2.json
@@ -1,0 +1,15 @@
+{
+  "object": "list",
+  "type": "user",
+  "user": {},
+  "results": [
+    {
+      "object": "bot",
+      "id": "55555555-5555-5555-5555-555555555555",
+      "name": "Notion-SDK-Harn",
+      "type": "bot"
+    }
+  ],
+  "has_more": false,
+  "next_cursor": null
+}

--- a/tests/recorded/notion_sdk_smoke.harn
+++ b/tests/recorded/notion_sdk_smoke.harn
@@ -1,0 +1,204 @@
+// Recorded HTTP smoke tests for the generated Notion SDK.
+//
+// Each scenario installs deterministic responses through `http_mock`,
+// invokes the SDK, and asserts the parsed payload, request shape, and
+// (for failure cases) the structured `NotionError` returned via
+// `decode_thrown`. No live HTTP traffic.
+import { collect_all, decode_thrown, paginate } from "../../src/helpers"
+import {
+  create_a_comment,
+  create_a_comment_variant1,
+  get_users,
+  new_client,
+  post_database_query,
+  retrieve_a_page,
+} from "../../src/lib"
+import { expect, expect_contains, expect_eq } from "../assertions"
+
+let BASE_URL = "https://api.notion.test"
+
+let TOKEN = "secret_test_token"
+
+let NOTION_VERSION = "2022-06-28"
+
+let PAGE_OK_PATH = "tests/fixtures/recorded/page_retrieve_ok.json"
+
+let PAGE_404_PATH = "tests/fixtures/recorded/page_retrieve_404.json"
+
+let DS_QUERY_PAGE_1_PATH = "tests/fixtures/recorded/data_source_query_page_1.json"
+
+let DS_QUERY_PAGE_2_PATH = "tests/fixtures/recorded/data_source_query_page_2.json"
+
+let DS_QUERY_429_PATH = "tests/fixtures/recorded/data_source_query_429.json"
+
+let COMMENT_OK_PATH = "tests/fixtures/recorded/comment_create_ok.json"
+
+let USERS_PAGE_1_PATH = "tests/fixtures/recorded/users_list_page_1.json"
+
+let USERS_PAGE_2_PATH = "tests/fixtures/recorded/users_list_page_2.json"
+
+fn fixture_client() {
+  return new_client(BASE_URL, TOKEN, nil, "", "", nil, {"Notion-Version": NOTION_VERSION})
+}
+
+@test
+pipeline default() {
+  // ---------------------------------------------------------------
+  // pages.retrieve — happy path
+  // ---------------------------------------------------------------
+  http_mock_clear()
+  let page_id = "11111111-1111-1111-1111-111111111111"
+  http_mock(
+    "GET",
+    BASE_URL + "/v1/pages/" + page_id,
+    {status: 200, body: read_file(PAGE_OK_PATH), headers: {"x-request-id": "req-page-ok"}},
+  )
+  let client = fixture_client()
+  let page = retrieve_a_page(client, page_id)
+  expect_eq(page.object, "page", "page object kind")
+  expect_eq(page.id, page_id, "page id round trip")
+  expect_eq(page.properties.Status.select.name, "Done", "deeply nested property decoded")
+  let calls = http_mock_calls({include_sensitive: true})
+  expect_eq(len(calls), 1, "one page retrieve call")
+  expect_eq(calls[0].method, "GET", "GET method")
+  expect_eq(calls[0].headers.authorization, "Bearer " + TOKEN, "bearer token applied")
+  expect_eq(calls[0].headers.get("notion-version"), NOTION_VERSION, "notion-version header pinned")
+  // ---------------------------------------------------------------
+  // pages.retrieve — 404 → structured NotionError via decode_thrown
+  // ---------------------------------------------------------------
+  http_mock_clear()
+  let missing_id = "99999999-9999-9999-9999-999999999999"
+  http_mock(
+    "GET",
+    BASE_URL + "/v1/pages/" + missing_id,
+    {status: 404, body: read_file(PAGE_404_PATH), headers: {"x-request-id": "req-404"}},
+  )
+  let missing = try {
+    retrieve_a_page(client, missing_id)
+  }
+  expect(is_err(missing), "404 returns Err")
+  let err_404 = decode_thrown(unwrap_err(missing))
+  expect_eq(err_404.status, 404, "decoded status")
+  expect_eq(err_404.code, "object_not_found", "decoded Notion code")
+  expect_contains(err_404.message, "Could not find page", "decoded Notion message")
+  expect_eq(err_404.operation, "retrieve_a_page", "decoded operation name")
+  // ---------------------------------------------------------------
+  // data_sources.query — paginated walk via paginate(...)
+  // ---------------------------------------------------------------
+  http_mock_clear()
+  let ds_id = "33333333-3333-3333-3333-333333333333"
+  http_mock(
+    "POST",
+    BASE_URL + "/v1/data_sources/" + ds_id + "/query",
+    {
+      responses: [
+        {status: 200, body: read_file(DS_QUERY_PAGE_1_PATH), headers: {"x-request-id": "req-ds-1"}},
+        {status: 200, body: read_file(DS_QUERY_PAGE_2_PATH), headers: {"x-request-id": "req-ds-2"}},
+      ],
+    },
+  )
+  let rows = collect_all(
+    fn(args) { return post_database_query(
+      client,
+      ds_id,
+      {filter: {property: "Status", select: {equals: "Done"}}, ...args},
+    ) },
+  )
+  expect_eq(len(rows), 3, "paginate concatenates results across pages")
+  expect_eq(rows[0].id, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", "first row id")
+  expect_eq(rows[2].id, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3", "last row id")
+  let query_calls = http_mock_calls()
+  expect_eq(len(query_calls), 2, "two POSTs for two-page result")
+  let first_body = json_parse(query_calls[0].body)
+  expect_eq(first_body.filter.property, "Status", "filter forwarded on page 1")
+  expect_eq(first_body.get("start_cursor"), nil, "no cursor on first page")
+  let second_body = json_parse(query_calls[1].body)
+  expect_eq(second_body.start_cursor, "page-2-cursor", "second page picks up cursor")
+  expect_eq(second_body.filter.property, "Status", "filter preserved across pages")
+  // ---------------------------------------------------------------
+  // data_sources.query — 429 → structured rate_limited error
+  // ---------------------------------------------------------------
+  http_mock_clear()
+  http_mock(
+    "POST",
+    BASE_URL + "/v1/data_sources/" + ds_id + "/query",
+    {
+      status: 429,
+      body: read_file(DS_QUERY_429_PATH),
+      headers: {"x-request-id": "req-429", "retry-after": "5"},
+    },
+  )
+  let throttled = try {
+    post_database_query(client, ds_id, {})
+  }
+  expect(is_err(throttled), "429 returns Err")
+  let err_429 = decode_thrown(unwrap_err(throttled))
+  expect_eq(err_429.status, 429, "decoded 429 status")
+  expect_eq(err_429.code, "rate_limited", "decoded Notion rate_limited code")
+  expect_eq(err_429.operation, "post_database_query", "decoded operation name")
+  // ---------------------------------------------------------------
+  // comments.create — variant1 (parent + rich_text)
+  // ---------------------------------------------------------------
+  http_mock_clear()
+  http_mock(
+    "POST",
+    BASE_URL + "/v1/comments",
+    {status: 200, body: read_file(COMMENT_OK_PATH), headers: {"x-request-id": "req-comment"}},
+  )
+  let body = create_a_comment_variant1(
+    {type: "page_id", page_id: page_id},
+    [{type: "text", text: {content: "Hello from notion-sdk-harn"}}],
+  )
+  let comment = create_a_comment(client, body)
+  expect_eq(comment.object, "comment", "comment object kind")
+  expect_eq(comment.id, "cccccccc-cccc-cccc-cccc-cccccccccccc", "comment id round trip")
+  let comment_calls = http_mock_calls()
+  expect_eq(len(comment_calls), 1, "one comments.create call")
+  let comment_body = json_parse(comment_calls[0].body)
+  expect_eq(comment_body.parent.page_id, page_id, "comment parent forwarded")
+  expect_eq(len(comment_body.rich_text), 1, "rich_text array forwarded")
+  expect_eq(comment_body.get("_variant"), nil, "internal _variant marker stripped before send")
+  // ---------------------------------------------------------------
+  // users.list — paginate via paginate(...) with explicit page_size
+  // ---------------------------------------------------------------
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE_URL + "/v1/users*",
+    {
+      responses: [
+        {status: 200, body: read_file(USERS_PAGE_1_PATH), headers: {"x-request-id": "req-users-1"}},
+        {status: 200, body: read_file(USERS_PAGE_2_PATH), headers: {"x-request-id": "req-users-2"}},
+      ],
+    },
+  )
+  let users = collect_all(fn(args) { return get_users(client, args.get("start_cursor"), 50) })
+  expect_eq(len(users), 3, "users.list paginates across two pages")
+  expect_eq(users[0].name, "Ada Lovelace", "first user")
+  expect_eq(users[2].type, "bot", "bot user on second page")
+  let user_calls = http_mock_calls()
+  expect_eq(len(user_calls), 2, "two GETs for two-page result")
+  expect_contains(user_calls[0].url, "page_size=50", "page_size forwarded as query param")
+  expect(user_calls[0].url.index_of("start_cursor=") < 0, "no start_cursor on first page")
+  expect_contains(user_calls[1].url, "start_cursor=users-page-2", "second page picks up cursor")
+  // ---------------------------------------------------------------
+  // paginate (lazy) — early stream termination after one item
+  // ---------------------------------------------------------------
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE_URL + "/v1/users*",
+    {status: 200, body: read_file(USERS_PAGE_1_PATH), headers: {}},
+  )
+  var first_only = nil
+  for u in paginate(fn(args) { return get_users(client, args.get("start_cursor"), nil) }) {
+    first_only = u
+    break
+  }
+  expect(first_only != nil, "stream yields at least one item")
+  expect_eq(first_only.id, "22222222-2222-2222-2222-222222222222", "first streamed user")
+  let lazy_calls = http_mock_calls()
+  expect_eq(len(lazy_calls), 1, "lazy paginate stops after first page when consumer breaks")
+  http_mock_clear()
+  println("notion_sdk_smoke: ok")
+}


### PR DESCRIPTION
## Summary

Closes [#2](https://github.com/burin-labs/notion-sdk-harn/issues/2), [#3](https://github.com/burin-labs/notion-sdk-harn/issues/3), [#4](https://github.com/burin-labs/notion-sdk-harn/issues/4).

- Add [\`src/helpers.harn\`](src/helpers.harn) with \`decode_thrown\` (parses generated SDK throws into a \`{status, code, message, request_id, body, operation}\` dict) and \`paginate\` / \`collect_all\` (Stream-based walk of any cursored Notion list endpoint).
- Bump package to \`v0.1.0\` and export the new \`helpers\` entry alongside the generated \`default\`.
- Add recorded \`http_mock\` smoke tests under [\`tests/recorded/\`](tests/recorded/notion_sdk_smoke.harn) covering pages, data sources, comments, and users with happy-path, 404, 429, paginated, and lazy-stream early-termination scenarios — no live HTTP traffic.
- Wire the recorded suite plus \`tests/\` check + lint + fmt into CI; expand the package install smoke to also import the helpers module so both exports are exercised end-to-end through the package manager.
- Rewrite the README to match the real (snake_case) generated surface, list the 70 supported operations grouped by resource, document the unsupported policy (webhooks belong in \`harn-notion-connector\`), API-version pinning conventions, and the structured error shape returned by \`decode_thrown\`.

## Test plan

- [x] \`harn check src scripts tests\`
- [x] \`harn lint src scripts tests\`
- [x] \`harn fmt --check src scripts tests\`
- [x] \`harn run scripts/regen.harn\` (drift check passes; lib.harn unchanged)
- [x] \`harn run tests/recorded/notion_sdk_smoke.harn\` exercises:
  - \`pages.retrieve\` happy path with bearer + Notion-Version header assertions
  - \`pages.retrieve\` 404 → \`decode_thrown\` returns structured \`{status: 404, code: "object_not_found", operation: "retrieve_a_page", ...}\`
  - \`data_sources.query\` paginated walk via \`collect_all(paginate(...))\` across two pages, asserting cursor and filter forwarding
  - \`data_sources.query\` 429 → structured \`rate_limited\` error
  - \`comments.create\` variant1 round-trip with \`_variant\` marker stripped before send
  - \`users.list\` paginated via \`paginate\` with explicit \`page_size\` query param
  - lazy \`paginate\` stream early-termination (consumer breaks after first item; only one HTTP call observed)
- [x] Local package install smoke: \`harn add\` from a temp project, then \`import { new_client } from "notion-sdk-harn"\` + \`import { decode_thrown, paginate } from "notion-sdk-harn/helpers"\`, and \`harn check\` the consumer.
- [x] Verified the existing \`harn-notion-connector\` import path (\`from "notion-sdk-harn/default"\`) continues to resolve.