### PR TITLE
[codex] Pin harn-openapi prerelease

### DIFF
--- a/harn.lock
+++ b/harn.lock
@@ -7,12 +7,12 @@ protocol_artifact_version = "0.8.32"
 [[package]]
 name = "harn-openapi"
 source = "git+https://github.com/burin-labs/harn-openapi"
-rev_request = "ab3e9baab793c86204c28d1383748616111f00b6"
-commit = "ab3e9baab793c86204c28d1383748616111f00b6"
-content_hash = "sha256:9b8b9affe2c8d7c33486cbfb61a09038ef54a2d36fd45ffec0f869b530fea334"
-package_version = "0.1.0"
+rev_request = "v0.1.1-rc.1"
+commit = "d23de27d753f2cdf8f116f4b14823100eb8d5716"
+content_hash = "sha256:78b445d8f0b7bf7ffc2cae6ec3b66113239b6264eb2a54e42f4f9fb4c1d6d2c3"
+package_version = "0.1.1-rc.1"
 harn_compat = ">=0.8,<0.9"
-manifest_digest = "sha256:4e5aedfa12c6b2b373fc707dd1c6da78abcf7754bdb87307b0508acdf51288f0"
+manifest_digest = "sha256:914eaa53c4c954c9414e3c0e89c572d2905032aadfeafba39854393b7c6b9493"
 
 [[package.exports.modules]]
 name = "default"

--- a/harn.toml
+++ b/harn.toml
@@ -15,4 +15,4 @@ helpers = "src/helpers.harn"
 # clean consumer project without a sibling checkout. Pin exact revisions for
 # reproducible codegen refreshes and package installs.
 [dependencies]
-harn-openapi = { git = "https://github.com/burin-labs/harn-openapi", rev = "ab3e9baab793c86204c28d1383748616111f00b6" }
+harn-openapi = { git = "https://github.com/burin-labs/harn-openapi", rev = "v0.1.1-rc.1" }


### PR DESCRIPTION
## Summary

- pin `harn-openapi` to the published `v0.1.1-rc.1` prerelease tag
- refresh `harn.lock` so package installs resolve the same generator

## Validation

- `harn install`
- `harn check src scripts`
- `harn lint src scripts`
- `harn fmt --check src scripts`
- `harn run scripts/regen.harn`
