### PR TITLE
ci: move GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read Harn version
         id: harn-version
@@ -28,7 +28,7 @@ jobs:
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Cache harn-cli
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .harn/ci-harn/${{ steps.harn-version.outputs.version }}


### PR DESCRIPTION
## Summary
- bump actions/checkout from v4 to v6
- bump actions/cache from v4 to v5
- remove the Node 20 deprecation warning emitted by CI after the Harn v0.8.43 upgrade

## Verification
- actionlint .github/workflows/ci.yml
- git diff --check